### PR TITLE
Updating version for terraform-azure-plan

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
   steps:
     - name: Terraform Plan Only
       if: ${{ contains(inputs.test_type, 'plan') }} || contains(inputs.test_type, 'apply') || ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@v1.0.0
+      uses: haflidif/terraform-azure-plan@bugfix/3-missing-github-token
       id: plan-only
       with:
         path: ${{ inputs.path }}
@@ -132,7 +132,7 @@ runs:
 
     - name: Terraform Plan -> Apply -> Destroy (Plan)
       if: ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@v1.0.0
+      uses: haflidif/terraform-azure-plan@bugfix/3-missing-github-token
       id: destroy-plan
       with:
         path: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
   steps:
     - name: Terraform Plan Only
       if: ${{ contains(inputs.test_type, 'plan') }} || contains(inputs.test_type, 'apply') || ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@bugfix/3-missing-github-token
+      uses: haflidif/terraform-azure-plan@v1.1.0
       id: plan-only
       with:
         path: ${{ inputs.path }}
@@ -132,7 +132,7 @@ runs:
 
     - name: Terraform Plan -> Apply -> Destroy (Plan)
       if: ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@bugfix/3-missing-github-token
+      uses: haflidif/terraform-azure-plan@v1.1.0
       id: destroy-plan
       with:
         path: ${{ inputs.path }}


### PR DESCRIPTION
This pull request includes updates to the `action.yml` file to use a newer version of the `terraform-azure-plan` action. The most important changes are:

* Updated the `Terraform Plan Only` step to use `haflidif/terraform-azure-plan@v1.1.0` instead of `v1.0.0`.
* Updated the `Terraform Plan -> Apply -> Destroy (Plan)` step to use `haflidif/terraform-azure-plan@v1.1.0` instead of `v1.0.0`.