### PR TITLE
Updating terraform-azure-plan to version v1.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
   steps:
     - name: Terraform Plan Only
       if: ${{ contains(inputs.test_type, 'plan') }} || contains(inputs.test_type, 'apply') || ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@v1.1.0
+      uses: haflidif/terraform-azure-plan@v1.2.0
       id: plan-only
       with:
         path: ${{ inputs.path }}
@@ -132,7 +132,7 @@ runs:
 
     - name: Terraform Plan -> Apply -> Destroy (Plan)
       if: ${{ contains(inputs.test_type, 'destroy') }}
-      uses: haflidif/terraform-azure-plan@v1.1.0
+      uses: haflidif/terraform-azure-plan@v1.2.0
       id: destroy-plan
       with:
         path: ${{ inputs.path }}


### PR DESCRIPTION
This pull request includes updates to the `action.yml` file to use a newer version of the `terraform-azure-plan` action.

Version updates:

* Updated `terraform-azure-plan` action to version `v1.2.0` in the `Terraform Plan Only` step (`action.yml`)
* Updated `terraform-azure-plan` action to version `v1.2.0` in the `Terraform Plan -> Apply -> Destroy (Plan)` step (`action.yml`)